### PR TITLE
Allow gem installation on Linux machines

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.14.0-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.14.0-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     pg (1.4.5)
     puma (5.6.5)
@@ -190,6 +192,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   annotate


### PR DESCRIPTION
Add x86_64-linux platform to allow native gem compilation on Linux machines.

Digital Ocean build failed:
```
[2023-01-25 16:35:30] │ -----> Installing dependencies using bundler 2.3.10
[2023-01-25 16:35:30] │        Running: BUNDLE_WITHOUT='development:test' BUNDLE_PATH=/layers/heroku_ruby/gems/vendor/bundle BUNDLE_BIN=vendor/bundle/bin BUNDLE_DEPLOYMENT=1 bundle install -j4
[2023-01-25 16:35:31] │        Your bundle only supports platforms ["arm64-darwin-22", "x86_64-darwin-21"] but
[2023-01-25 16:35:31] │        your local platform is x86_64-linux. Add the current platform to the lockfile
[2023-01-25 16:35:31] │        with
[2023-01-25 16:35:31] │        `bundle lock --add-platform x86_64-linux` and try again.
[2023-01-25 16:35:31] │        Bundler Output: Your bundle only supports platforms ["arm64-darwin-22", "x86_64-darwin-21"] but
[2023-01-25 16:35:31] │        your local platform is x86_64-linux. Add the current platform to the lockfile
[2023-01-25 16:35:31] │        with
[2023-01-25 16:35:31] │        `bundle lock --add-platform x86_64-linux` and try again.
[2023-01-25 16:35:31] │ 
[2023-01-25 16:35:31] │  !
[2023-01-25 16:35:31] │  !     Failed to install gems via Bundler.
[2023-01-25 16:35:31] │  !
[2023-01-25 16:35:31] │ ERROR: failed to build: exit status 1
[2023-01-25 16:35:31] │ 
```